### PR TITLE
Clarify expression base node and statement base node

### DIFF
--- a/src/ast/assign.rs
+++ b/src/ast/assign.rs
@@ -2,24 +2,24 @@ use std::collections::HashMap;
 
 use crate::error::InterpreterError;
 
-use super::{ASTNode, VarNode};
+use super::{ASTExpression, ASTNode, VarNode};
 
 pub struct AssignNode {
     var: Box<VarNode>,
-    expr: Box<dyn ASTNode>,
+    expression: Box<dyn ASTExpression>,
 }
 
 impl AssignNode {
-    pub fn new(var: Box<VarNode>, expr: Box<dyn ASTNode>) -> Self {
-        Self { var, expr }
+    pub fn new(var: Box<VarNode>, expression: Box<dyn ASTExpression>) -> Self {
+        Self { var, expression }
     }
 }
 
 impl ASTNode for AssignNode {
-    fn eval(&self, symtab: &mut HashMap<String, f64>) -> Result<f64, InterpreterError> {
-        let value = self.expr.eval(symtab)?;
+    fn execute(&self, symtab: &mut HashMap<String, f64>) -> Result<f64, InterpreterError> {
+        let value = self.expression.eval(symtab)?;
 
-        symtab.insert(self.var.get_name().to_string(), value);
+        symtab.insert(self.var.name().to_string(), value);
 
         Ok(value)
     }

--- a/src/ast/ast.rs
+++ b/src/ast/ast.rs
@@ -3,5 +3,11 @@ use std::collections::HashMap;
 use crate::error::InterpreterError;
 
 pub trait ASTNode {
+    fn execute(&self, symtab: &mut HashMap<String, f64>) -> Result<f64, InterpreterError>;
+}
+
+pub trait ASTExpression {
+    fn pure(&self) -> bool;
+
     fn eval(&self, symtab: &mut HashMap<String, f64>) -> Result<f64, InterpreterError>;
 }

--- a/src/ast/binary.rs
+++ b/src/ast/binary.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::error::InterpreterError;
 
-use super::ASTExpression;
+use super::{ASTExpression, ASTNode};
 
 pub enum BinaryOpType {
     ADD,
@@ -28,6 +28,12 @@ impl BinaryOpNode {
             right,
             op_type,
         }
+    }
+}
+
+impl ASTNode for BinaryOpNode {
+    fn execute(&self, symtab: &mut HashMap<String, f64>) -> Result<f64, InterpreterError> {
+        self.eval(symtab)
     }
 }
 

--- a/src/ast/binary.rs
+++ b/src/ast/binary.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::error::InterpreterError;
 
-use super::ast::ASTNode;
+use super::ASTExpression;
 
 pub enum BinaryOpType {
     ADD,
@@ -12,18 +12,30 @@ pub enum BinaryOpType {
 }
 
 pub struct BinaryOpNode {
-    left: Box<dyn ASTNode>,
-    right: Box<dyn ASTNode>,
+    left: Box<dyn ASTExpression>,
+    right: Box<dyn ASTExpression>,
     op_type: BinaryOpType,
 }
 
 impl BinaryOpNode {
-    pub fn new(left: Box<dyn ASTNode>, right: Box<dyn ASTNode>, op_type: BinaryOpType) -> Self {
-        Self { left, right, op_type }
+    pub fn new(
+        left: Box<dyn ASTExpression>,
+        right: Box<dyn ASTExpression>,
+        op_type: BinaryOpType,
+    ) -> Self {
+        Self {
+            left,
+            right,
+            op_type,
+        }
     }
 }
 
-impl ASTNode for BinaryOpNode {
+impl ASTExpression for BinaryOpNode {
+    fn pure(&self) -> bool {
+        self.left.pure() && self.right.pure()
+    }
+
     fn eval(&self, symtab: &mut HashMap<String, f64>) -> Result<f64, InterpreterError> {
         let left = self.left.eval(symtab)?;
         let right = self.right.eval(symtab)?;

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -7,7 +7,7 @@ mod unary;
 mod var;
 
 pub use assign::AssignNode;
-pub use ast::ASTNode;
+pub use ast::{ASTNode, ASTExpression};
 pub use binary::{BinaryOpNode, BinaryOpType};
 pub use number::NumberNode;
 pub use statement::StatementListNode;

--- a/src/ast/number.rs
+++ b/src/ast/number.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::error::InterpreterError;
 
-use super::ASTExpression;
+use super::{ASTExpression, ASTNode};
 
 pub struct NumberNode {
     value: f64,
@@ -11,6 +11,12 @@ pub struct NumberNode {
 impl NumberNode {
     pub fn new(value: f64) -> Self {
         Self { value }
+    }
+}
+
+impl ASTNode for NumberNode {
+    fn execute(&self, symtab: &mut HashMap<String, f64>) -> Result<f64, InterpreterError> {
+        self.eval(symtab)
     }
 }
 

--- a/src/ast/number.rs
+++ b/src/ast/number.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::error::InterpreterError;
 
-use super::ast::ASTNode;
+use super::ASTExpression;
 
 pub struct NumberNode {
     value: f64,
@@ -14,8 +14,12 @@ impl NumberNode {
     }
 }
 
-impl ASTNode for NumberNode {
-    fn eval(&self, symtab: &mut HashMap<String, f64>) -> Result<f64, InterpreterError> {
+impl ASTExpression for NumberNode {
+    fn pure(&self) -> bool {
+        true
+    }
+
+    fn eval(&self, _symtab: &mut HashMap<String, f64>) -> Result<f64, InterpreterError> {
         Ok(self.value)
     }
 }

--- a/src/ast/statement.rs
+++ b/src/ast/statement.rs
@@ -15,11 +15,11 @@ impl StatementListNode {
 }
 
 impl ASTNode for StatementListNode {
-    fn eval(&self, symtab: &mut HashMap<String, f64>) -> Result<f64, InterpreterError> {
+    fn execute(&self, symtab: &mut HashMap<String, f64>) -> Result<f64, InterpreterError> {
         let mut value: f64 = 0.;
 
         for node in self.nodes.iter() {
-            value = node.eval(symtab)?;
+            value = node.execute(symtab)?;
         }
 
         Ok(value)

--- a/src/ast/unary.rs
+++ b/src/ast/unary.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::error::InterpreterError;
 
-use super::ASTExpression;
+use super::{ASTExpression, ASTNode};
 
 pub enum UnaryOpType {
     PLUS,
@@ -17,6 +17,12 @@ pub struct UnaryOpNode {
 impl UnaryOpNode {
     pub fn new(node: Box<dyn ASTExpression>, op_type: UnaryOpType) -> Self {
         Self { node, op_type }
+    }
+}
+
+impl ASTNode for UnaryOpNode {
+    fn execute(&self, symtab: &mut HashMap<String, f64>) -> Result<f64, InterpreterError> {
+        self.eval(symtab)
     }
 }
 

--- a/src/ast/unary.rs
+++ b/src/ast/unary.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::error::InterpreterError;
 
-use super::ast::ASTNode;
+use super::ASTExpression;
 
 pub enum UnaryOpType {
     PLUS,
@@ -10,17 +10,21 @@ pub enum UnaryOpType {
 }
 
 pub struct UnaryOpNode {
-    node: Box<dyn ASTNode>,
+    node: Box<dyn ASTExpression>,
     op_type: UnaryOpType,
 }
 
 impl UnaryOpNode {
-    pub fn new(node: Box<dyn ASTNode>, op_type: UnaryOpType) -> Self {
+    pub fn new(node: Box<dyn ASTExpression>, op_type: UnaryOpType) -> Self {
         Self { node, op_type }
     }
 }
 
-impl ASTNode for UnaryOpNode {
+impl ASTExpression for UnaryOpNode {
+    fn pure(&self) -> bool {
+        self.node.pure()
+    }
+
     fn eval(&self, symtab: &mut HashMap<String, f64>) -> Result<f64, InterpreterError> {
         let value = self.node.eval(symtab)?;
 

--- a/src/ast/var.rs
+++ b/src/ast/var.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::error::InterpreterError;
 
-use super::ASTExpression;
+use super::{ASTExpression, ASTNode};
 
 pub struct VarNode {
     name: String,
@@ -15,6 +15,12 @@ impl VarNode {
 
     pub fn name(&self) -> &String {
         &self.name
+    }
+}
+
+impl ASTNode for VarNode {
+    fn execute(&self, symtab: &mut HashMap<String, f64>) -> Result<f64, InterpreterError> {
+        self.eval(symtab)
     }
 }
 

--- a/src/ast/var.rs
+++ b/src/ast/var.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::error::InterpreterError;
 
-use super::ASTNode;
+use super::ASTExpression;
 
 pub struct VarNode {
     name: String,
@@ -13,12 +13,16 @@ impl VarNode {
         Self { name }
     }
 
-    pub fn get_name(&self) -> &String {
+    pub fn name(&self) -> &String {
         &self.name
     }
 }
 
-impl ASTNode for VarNode {
+impl ASTExpression for VarNode {
+    fn pure(&self) -> bool {
+        false
+    }
+
     fn eval(&self, symtab: &mut HashMap<String, f64>) -> Result<f64, InterpreterError> {
         symtab
             .get(&self.name)

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -28,7 +28,7 @@ impl Interpreter {
         let tokens = Tokenizer::new(content).try_collect()?;
         let statement_list_node = Parser::new(tokens).parse()?;
 
-        let value = statement_list_node.eval(&mut self.symtab)?;
+        let value = statement_list_node.execute(&mut self.symtab)?;
         self.nodes.push(statement_list_node);
 
         Ok(value)


### PR DESCRIPTION
## Motivation

To add semantic checking to AST, we should have a way to distinguish statement and expression.

## Changes

1. Add ASTExpression trait for expression-based ASTNode
2. Clarify all dyn ASTNode type.